### PR TITLE
Fix filtering out finished topics

### DIFF
--- a/src/react/context/index.tsx
+++ b/src/react/context/index.tsx
@@ -1274,7 +1274,7 @@ const EscolaLMSContextProviderInner: FunctionComponent<
           course.progress.length;
         acc.finishedTopics = acc.finishedTopics.concat(
           course.progress
-            .filter((item) => item.status !== 0)
+            .filter((item) => item.status === 1)
             .map((item) => item.topic_id)
         );
         return acc;


### PR DESCRIPTION
jesli 0 to not-finished, 1 to finished, a 2 to in progress, to nie wystarczy sprawdzenie czy status nie jest 0 => musi być równy 1