### PR TITLE
[WC-932] - Add getImageSvgPrefix function to get prefix for .svg files

### DIFF
--- a/src/react/components/Image/index.tsx
+++ b/src/react/components/Image/index.tsx
@@ -40,7 +40,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(
     imgRef
   ) => {
     const [cached, setCached] = useState(false);
-    const { apiUrl, getImagePrefix } = useContext(EscolaLMSContext);
+    const { apiUrl, getImagePrefix, getImageSvgPrefix } = useContext(EscolaLMSContext);
 
     const imgSize = useMemo(
       () => (srcSizes?.[0] ? srcSizes[0] : size),
@@ -113,7 +113,7 @@ const Image = forwardRef<HTMLImageElement, ImageProps>(
             loading={"lazy"}
             ref={imgRef}
             onError={cached ? undefined : onError}
-            src={`${getImagePrefix()}${path}}`}
+            src={`${getImageSvgPrefix()}${path}`}
             alt={alt}
             {...props}
           />

--- a/src/react/context/defaults.ts
+++ b/src/react/context/defaults.ts
@@ -28,6 +28,7 @@ export const defaultReadConfig: EscolaLMSContextConfig = {
   apiUrl: "",
 
   getImagePrefix: () => "",
+  getImageSvgPrefix: () => "",
   courses: {
     loading: false,
   },
@@ -323,6 +324,7 @@ export const defaultApiConfig: EscolaLMSContextConfig = {
   },
   fetchMyCourses: () => Promise.reject(),
   getImagePrefix: () => "",
+  getImageSvgPrefix: () => "",
   courses: {
     loading: false,
   },

--- a/src/react/context/index.tsx
+++ b/src/react/context/index.tsx
@@ -190,6 +190,7 @@ export interface EscolaLMSContextProviderType {
   apiUrl: string;
   defaults?: Partial<EscolaLMSContextReadConfig>;
   imagePrefix?: string;
+  imageSvgPrefix?: string;
   initialFetch?: boolean;
   ssrHydration?: boolean;
 }
@@ -206,6 +207,7 @@ const EscolaLMSContextProviderInner: FunctionComponent<
   apiUrl,
   defaults,
   imagePrefix = `${apiUrl}/storage/imgcache`,
+  imageSvgPrefix = `${apiUrl}/storage`,
   initialFetch = true,
   ssrHydration = false,
 }) => {
@@ -216,6 +218,7 @@ const EscolaLMSContextProviderInner: FunctionComponent<
   };
 
   const getImagePrefix = () => imagePrefix;
+  const getImageSvgPrefix = () => imageSvgPrefix;
 
   const {
     token,
@@ -1699,6 +1702,7 @@ const EscolaLMSContextProviderInner: FunctionComponent<
         fetchOrderInvoice,
         addMissingProducts,
         getImagePrefix,
+        getImageSvgPrefix,
         changeConsultationTerm,
         fetchProducts,
         fetchProduct,

--- a/src/react/context/types.ts
+++ b/src/react/context/types.ts
@@ -86,6 +86,7 @@ export interface EscolaLMSContextReadConfig {
 export interface EscolaLMSContextAPIConfig {
   apiUrl: string;
   getImagePrefix: () => string;
+  getImageSvgPrefix: () => string;
   fetchCourses: (
     filter: API.CourseParams
   ) => Promise<API.DefaultMetaResponse<API.Course>>;


### PR DESCRIPTION
[WC-932]
Add getImageSvgPrefix function to get prefix for .svg files.

https://escl24.atlassian.net/browse/WC-932

[WC-932]: https://escl24.atlassian.net/browse/WC-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ